### PR TITLE
BACKLOG-22915: Update the version of the checkout action

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Compile
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set environment variables from parameters
       shell: bash
       run: |
@@ -34,7 +34,7 @@ jobs:
       matrix:
         profile: [tomcat, jetty, undertow]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: actions/cache@v1
       with:
         path: ~/.m2/repository

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -s .github/maven.settings.xml -pl pax-web-jsp -Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true deploy
+      run: mvn -s .github/maven.settings.xml -Dcheckstyle.skip=true -DskipLocalStaging=true -Dfindbugs.skip=true deploy
   build:
     runs-on: ubuntu-latest
     needs: compile

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Compile
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set environment variables from parameters
         shell: bash
         run: |


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22915

## Description

The release failed when pushing the tag deletion with:
```
git tag --delete web-7.3.7-jahia3
Deleted tag 'web-7.3.7-jahia3' (was a09d[8](https://github.com/Jahia/org.ops4j.pax.web/actions/runs/9449357252/job/26025421874#step:5:8)1a18)

git push origin :refs/tags/web-7.3.7-jahia3
fatal: could not read Username for 'https://github.com': No such device or address
```

From https://stackoverflow.com/a/20871910/22921138 it seems to be an [issue with the Git version](https://stackoverflow.com/questions/20871549/error-when-push-commits-with-github-fatal-could-not-read-username/20884273#20884273) used so first try is to update the checkout action version and if it does not work we'll add these steps:
```
git remote rm origin
git remote add origin 'git:git@github.com:Jahia/org.ops4j.pax.web.git'
```