### PR TITLE
BACKLOG-22915: Add branch ref for the checkout step

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -12,6 +12,8 @@ jobs:
     name: Compile
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: pax-web-7.3.7-jahia
       - name: Set environment variables from parameters
         shell: bash
         run: |


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22915

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

From https://stackoverflow.com/questions/20351051/git-fatal-ref-head-is-not-a-symbolic-ref-while-using-maven-release-plugin/62713096#62713096 