### PR TITLE
chore: bump bouncycastle from 1.80 to 1.84

### DIFF
--- a/.chachalog/2HW2OlVP.md
+++ b/.chachalog/2HW2OlVP.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+org.ops4j.pax.web: patch
+---
+
+Updated bouncycastle from 1.80 to 1.84 (#40)

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
 		<dependency.org.apache.ws.xmlschema>2.3.1</dependency.org.apache.ws.xmlschema>
 		<dependency.org.apache.xbean>4.26</dependency.org.apache.xbean>
 
-		<dependency.org.bouncycastle>1.80</dependency.org.bouncycastle>
+		<dependency.org.bouncycastle>1.84</dependency.org.bouncycastle>
 
 		<dependency.org.codehaus.woodstox.stax2-api>4.2.2</dependency.org.codehaus.woodstox.stax2-api>
 


### PR DESCRIPTION
Updated to the latest version (see parent issue).

Note that I did not update here: https://github.com/Jahia/org.ops4j.pax.web/blob/9bb16011044744459fce35e30724c3fd7e56f1f4/pax-web-itest/pax-web-itest-keycloak/pom.xml#L111-L112, afraid it might have side effects (see comment)